### PR TITLE
Hourly weather

### DIFF
--- a/app/controllers/api/v1/forecast_controller.rb
+++ b/app/controllers/api/v1/forecast_controller.rb
@@ -1,15 +1,29 @@
 class Api::V1::ForecastController < ApplicationController
 
   def show
-    location = params[:location].split(",")
+    city = find_city(params[:location])
+    @location = LocationSerializer.new(city)
+    @current = CurrentTemperatureSerializer.new(CurrentTemperature.find_by(location_id: city.id))
+    @hourly = HourlyTemperatureSerializer.new(HourlyTemperature.where(location_id: city.id))
+    @weekly = WeeklyTemperatureSerializer.new(WeeklyTemperature.where(location_id: city.id))
+    get_json
+  end
+
+  private
+
+  def find_city(location)
+    location = location.split(",")
     city = Location.find_by(city_state: "#{location[0].capitalize}, #{location[1].upcase}")
-    location = LocationSerializer.new(city)
-    current = CurrentTemperatureSerializer.new(CurrentTemperature.find_by(location_id: city.id))
-    @content = {
-       location: location.as_json(except: [:id, :type]),
-       current: current.as_json(except: [:id, :type])
+  end
+
+  def get_json
+    content = {
+       location: @location.as_json(except: [:id, :type]),
+       current: @current.as_json(except: [:id, :type]),
+       hourly: @hourly.as_json(except: [:id, :type]),
+       weekly: @weekly.as_json(except: [:id, :type])
     }
 
-    render json: { :forecast => @content }
+    render json: { :forecast => content }
   end
 end

--- a/app/models/hourly_temperature.rb
+++ b/app/models/hourly_temperature.rb
@@ -1,0 +1,3 @@
+class HourlyTemperature < ApplicationRecord
+  belongs_to :location
+end

--- a/app/models/weekly_temperature.rb
+++ b/app/models/weekly_temperature.rb
@@ -1,0 +1,3 @@
+class WeeklyTemperature < ApplicationRecord
+  belongs_to :location
+end

--- a/app/serializers/hourly_temperature_serializer.rb
+++ b/app/serializers/hourly_temperature_serializer.rb
@@ -1,0 +1,4 @@
+class HourlyTemperatureSerializer
+  include FastJsonapi::ObjectSerializer
+  attributes :temperature, :time, :icon
+end

--- a/app/serializers/weekly_temperature_serializer.rb
+++ b/app/serializers/weekly_temperature_serializer.rb
@@ -1,0 +1,4 @@
+class WeeklyTemperatureSerializer
+  include FastJsonapi::ObjectSerializer
+  attributes :high_temp, :low_temp, :chance_precip, :time, :icon
+end

--- a/app/services/dark_sky_service.rb
+++ b/app/services/dark_sky_service.rb
@@ -1,0 +1,23 @@
+class DarkSkyService
+  def initialize(lat, long)
+    @lat = lat
+    @long = long
+  end
+
+  def get_weather
+    get_json("/forecast/#{ENV['darksky-key']}/#{@lat},#{@long}")
+  end
+
+  private
+
+  def conn
+    Faraday.new(url: "https://api.darksky.net/") do |f|
+      f.adapter Faraday.default_adapter
+    end
+  end
+
+  def get_json(url)
+    response = conn.get(url)
+    JSON.parse(response.body, symbolize_names: true)
+  end
+end

--- a/app/services/google_service.rb
+++ b/app/services/google_service.rb
@@ -1,0 +1,23 @@
+class GoogleService
+  def initialize(city)
+    @city = city
+  end
+
+  def get_coords
+    get_json("/maps/api/geocode/json?components=locality:#{@city}|country:US")
+  end
+
+  private
+
+  def conn
+    Faraday.new('https://maps.googleapis.com/') do |f|
+      f.params[:key] = ENV["google-key"]
+      f.adapter Faraday.default_adapter
+    end
+  end
+
+  def get_json(url)
+    response = conn.get(url)
+    JSON.parse(response.body, symbolize_names: true)[:results][0][:geometry][:location]
+  end
+end

--- a/db/migrate/20190602230138_create_hourly_temperature.rb
+++ b/db/migrate/20190602230138_create_hourly_temperature.rb
@@ -1,0 +1,12 @@
+class CreateHourlyTemperature < ActiveRecord::Migration[5.2]
+  def change
+    create_table :hourly_temperatures do |t|
+      t.string :time
+      t.string :icon
+      t.float :temperature
+      t.references :location, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190602235726_create_weekly_temperature.rb
+++ b/db/migrate/20190602235726_create_weekly_temperature.rb
@@ -1,0 +1,12 @@
+class CreateWeeklyTemperature < ActiveRecord::Migration[5.2]
+  def change
+    create_table :weekly_temperatures do |t|
+      t.references :location, foreign_key: true
+      t.string :time
+      t.float :chance_precip
+      t.string :icon
+      t.float :high_temp
+      t.float :low_temp
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_02_221505) do
+ActiveRecord::Schema.define(version: 2019_06_02_235726) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -32,6 +32,16 @@ ActiveRecord::Schema.define(version: 2019_06_02_221505) do
     t.index ["location_id"], name: "index_current_temperatures_on_location_id"
   end
 
+  create_table "hourly_temperatures", force: :cascade do |t|
+    t.string "time"
+    t.string "icon"
+    t.float "temperature"
+    t.bigint "location_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["location_id"], name: "index_hourly_temperatures_on_location_id"
+  end
+
   create_table "locations", force: :cascade do |t|
     t.string "city_state"
     t.string "lat"
@@ -41,5 +51,17 @@ ActiveRecord::Schema.define(version: 2019_06_02_221505) do
     t.string "country"
   end
 
+  create_table "weekly_temperatures", force: :cascade do |t|
+    t.bigint "location_id"
+    t.string "time"
+    t.float "chance_precip"
+    t.string "icon"
+    t.float "high_temp"
+    t.float "low_temp"
+    t.index ["location_id"], name: "index_weekly_temperatures_on_location_id"
+  end
+
   add_foreign_key "current_temperatures", "locations"
+  add_foreign_key "hourly_temperatures", "locations"
+  add_foreign_key "weekly_temperatures", "locations"
 end

--- a/lib/tasks/cities.rake
+++ b/lib/tasks/cities.rake
@@ -16,15 +16,9 @@ namespace :cities do
       "New Orleans, LA", "Arlington, TX"]
 
       cities.each do |city|
-        @conn = Faraday.new('https://maps.googleapis.com/') do |f|
-          f.params[:key] = ENV["google-key"]
-          f.adapter Faraday.default_adapter
-        end
-
-        response = @conn.get("/maps/api/geocode/json?components=locality:#{city}|country:US")
-        @location = JSON.parse(response.body, symbolize_names: true)[:results][0][:geometry][:location]
-
-        Location.create(city_state: city, country: "United States", lat: @location[:lat], long: @location[:lng])
+        service = GoogleService.new(city)
+        location = service.get_coords
+        Location.create(city_state: city, country: "United States", lat: location[:lat], long: location[:lng])
       end
   end
 end

--- a/lib/tasks/forecast.rake
+++ b/lib/tasks/forecast.rake
@@ -9,6 +9,10 @@ namespace :forecast do
         @weather = JSON.parse(response.body, symbolize_names: true)
         current_weather = @weather[:currently]
         daily_weather =  @weather[:daily][:data]
+        hourly_weather = @weather[:hourly][:data]
+
+        current = CurrentTemperature.find_by(location_id: city.id)
+        current.destroy
         CurrentTemperature.create(location: city,
                                   temperature: current_weather[:temperature],
                                   summary: current_weather[:summary],
@@ -20,6 +24,33 @@ namespace :forecast do
                                   uvindex: current_weather[:uvIndex],
                                   high_temp: daily_weather.first[:temperatureHigh],
                                   low_temp: daily_weather.first[:temperatureLow])
+
+
+        hourly = HourlyTemperature.where(location_id: city.id)
+        hourly.each do |hour|
+          hour.destroy
+        end
+
+        hourly_weather.each do |hour|
+          HourlyTemperature.create(location: city,
+                                   time: hour[:time],
+                                   temperature: hour[:temperature],
+                                   icon: hour[:icon])
+        end
+
+        weekly = WeeklyTemperature.where(location_id: city.id)
+        weekly.each do |week|
+          week.destroy
+        end
+        
+        daily_weather.each do |day|
+          WeeklyTemperature.create(location: city,
+                                   time: day[:time],
+                                   high_temp: day[:temperatureHigh],
+                                   low_temp: day[:temperatureLow],
+                                   icon: day[:icon],
+                                   chance_precip: day[:precipProbability])
+        end
       end
   end
 end

--- a/spec/requests/api/vi/user_can_search_by_city_spec.rb
+++ b/spec/requests/api/vi/user_can_search_by_city_spec.rb
@@ -58,4 +58,141 @@ describe 'Weather API' do
     expect(data["low_temp"]).to eq(65.04)
     expect(data["full_summary"]).to eq("Light rain starting in the afternoon, continuing until evening.")
   end
+
+  it 'displays hourly weather data' do
+    location = Location.create(city_state: "Denver, CO", country: "United States", lat: "39.7392358", long: "-104.990251")
+    current_temperature = CurrentTemperature.create(location: location,
+                                                    temperature: 74.03,
+                                                    feels_like: 74.03,
+                                                    uvindex: 8,
+                                                    summary: "Partly Cloudy",
+                                                    full_summary: "Light rain starting in the afternoon, continuing until evening.",
+                                                    icon: "partly-cloudy-day",
+                                                    humidity: 0.34,
+                                                    visibility: 8.14,
+                                                    high_temp: 77.01,
+                                                    low_temp: 65.04)
+
+    hourly_temperature_1 = HourlyTemperature.create(location: location,
+                                                  time: "1559412000",
+                                                  icon: "partly-cloudy-day",
+                                                  temperature: 74.03)
+    hourly_temperature_2 = HourlyTemperature.create(location: location,
+                                                  time: "1559415600",
+                                                  icon: "partly-cloudy-day",
+                                                  temperature: 74.16)
+    hourly_temperature_3 = HourlyTemperature.create(location: location,
+                                                  time: "1559419200",
+                                                  icon: "partly-cloudy-day",
+                                                  temperature: 72.08)
+    hourly_temperature_4 = HourlyTemperature.create(location: location,
+                                                  time: "1559422800",
+                                                  icon: "rain",
+                                                  temperature: 68.88)
+    hourly_temperature_5 = HourlyTemperature.create(location: location,
+                                                  time: "1559426400",
+                                                  icon: "rain",
+                                                  temperature: 67.57)
+    hourly_temperature_6 = HourlyTemperature.create(location: location,
+                                                  time: "1559430000",
+                                                  icon: "rain",
+                                                  temperature: 69.04)
+    hourly_temperature_7 = HourlyTemperature.create(location: location,
+                                                  time: "1559433600",
+                                                  icon: "rain",
+                                                  temperature: 67.35)
+    hourly_temperature_8 = HourlyTemperature.create(location: location,
+                                                time: "1559437200",
+                                                  icon: "rain",
+                                                  temperature: 67.24)
+
+    get '/api/v1/forecast?location=denver,co'
+
+    expect(response).to be_successful
+
+    data = JSON.parse(response.body)["forecast"]["hourly"]["data"]
+    expect(data[0]["attributes"]["temperature"]).to eq(74.03)
+    expect(data[1]["attributes"]["time"]).to eq("1559415600")
+    expect(data[2]["attributes"]["icon"]).to eq("partly-cloudy-day")
+    expect(data[3]["attributes"]["temperature"]).to eq(68.88)
+    expect(data[4]["attributes"]["time"]).to eq("1559426400")
+    expect(data[5]["attributes"]["icon"]).to eq("rain")
+    expect(data[6]["attributes"]["temperature"]).to eq(67.35)
+    expect(data[7]["attributes"]["time"]).to eq("1559437200")
+  end
+
+  it 'displays weekly weather data' do
+    location = Location.create(city_state: "Denver, CO", country: "United States", lat: "39.7392358", long: "-104.990251")
+    current_temperature = CurrentTemperature.create(location: location,
+                                                    temperature: 74.03,
+                                                    feels_like: 74.03,
+                                                    uvindex: 8,
+                                                    summary: "Partly Cloudy",
+                                                    full_summary: "Light rain starting in the afternoon, continuing until evening.",
+                                                    icon: "partly-cloudy-day",
+                                                    humidity: 0.34,
+                                                    visibility: 8.14,
+                                                    high_temp: 77.01,
+                                                    low_temp: 65.04)
+    hourly_temperature_1 = HourlyTemperature.create(location: location,
+                                                  time: "1559412000",
+                                                  icon: "partly-cloudy-day",
+                                                  temperature: 74.03)
+
+    weekly_temperature_1 = WeeklyTemperature.create(location: location,
+                                                  time: "1559412000",
+                                                  chance_precip: 0.42,
+                                                  icon: "partly-cloudy-day",
+                                                  high_temp: 74.03,
+                                                  low_temp: 53.14)
+    weekly_temperature_2 = WeeklyTemperature.create(location: location,
+                                                  time: "1559415600",
+                                                  chance_precip: 0.44,
+                                                  icon: "partly-cloudy-day",
+                                                  high_temp: 74.16,
+                                                  low_temp: 48.23)
+    weekly_temperature_3 = WeeklyTemperature.create(location: location,
+                                                  time: "1559419200",
+                                                  chance_precip: 0.45,
+                                                  icon: "partly-cloudy-day",
+                                                  high_temp: 72.08,
+                                                  low_temp: 51.03)
+    weekly_temperature_4 = WeeklyTemperature.create(location: location,
+                                                  time: "1559422800",
+                                                  chance_precip: 0.62,
+                                                  icon: "rain",
+                                                  high_temp: 68.88,
+                                                  low_temp: 56.52)
+    weekly_temperature_5 = WeeklyTemperature.create(location: location,
+                                                  time: "1559426400",
+                                                  chance_precip: 0.72,
+                                                  icon: "rain",
+                                                  high_temp: 67.57,
+                                                  low_temp: 50.02)
+    weekly_temperature_6 = WeeklyTemperature.create(location: location,
+                                                  time: "1559430000",
+                                                  chance_precip: 0.45,
+                                                  icon: "rain",
+                                                  high_temp: 69.04,
+                                                  low_temp: 52.57)
+    weekly_temperature_7 = WeeklyTemperature.create(location: location,
+                                                  time: "1559433600",
+                                                  chance_precip: 0.42,
+                                                  icon: "rain",
+                                                  high_temp: 67.35,
+                                                  low_temp: 58.09)
+
+    get '/api/v1/forecast?location=denver,co'
+
+    expect(response).to be_successful
+
+    data = JSON.parse(response.body)["forecast"]["weekly"]["data"]
+    expect(data[0]["attributes"]["time"]).to eq("1559412000")
+    expect(data[1]["attributes"]["chance_precip"]).to eq(0.44)
+    expect(data[2]["attributes"]["icon"]).to eq("partly-cloudy-day")
+    expect(data[3]["attributes"]["high_temp"]).to eq(68.88)
+    expect(data[4]["attributes"]["low_temp"]).to eq(50.02)
+    expect(data[5]["attributes"]["time"]).to eq("1559430000")
+    expect(data[6]["attributes"]["chance_precip"]).to eq(0.42)
+  end
 end


### PR DESCRIPTION
Closes #9 
Closes #10 

- Creates test to assert that a city's hourly and weekly forecasts are displayed on the forecast endpoint
- Creates table for hourly_temperature, that includes: time, icon, and temperature. Foreign Key: location_id
- Creates table for weekly_temperature, that includes: time, chance_precip, icon, high_temp, low_temp. Foreign Key: location_id
- Creates models and serializers for hourly_temperature and weekly_temperature
- Refactors city & forecast rake tasks to utilize a GoogleService and DarkSkyService. Actual API calls are moved into these services. 