### PR TITLE
Updates forecast controller to add new city from search if not in db

### DIFF
--- a/app/controllers/api/v1/forecast_controller.rb
+++ b/app/controllers/api/v1/forecast_controller.rb
@@ -14,6 +14,19 @@ class Api::V1::ForecastController < ApplicationController
   def find_city(location)
     location = location.split(",")
     city = Location.find_by(city_state: "#{location[0].capitalize}, #{location[1].upcase}")
+    if city == nil
+      city = create_city(location)
+    end
+    city
+  end
+
+  def create_city(location)
+    city = "#{location[0].capitalize}, #{location[1].upcase}"
+    google_service = GoogleService.new(city)
+    location = google_service.get_coords
+    image_service = PixabayService.new(city)
+    image = image_service.get_background
+    Location.create(city_state: city, country: "United States", lat: location[:lat], long: location[:lng], background_image: image)
   end
 
   def get_json
@@ -25,5 +38,9 @@ class Api::V1::ForecastController < ApplicationController
     }
 
     render json: { :forecast => content }
+  end
+
+  def google_service
+    GoogleService.new(@city_state)
   end
 end

--- a/spec/requests/api/v1/user_can_search_by_city_spec.rb
+++ b/spec/requests/api/v1/user_can_search_by_city_spec.rb
@@ -195,4 +195,11 @@ describe 'Weather API' do
     expect(data[5]["attributes"]["time"]).to eq("1559430000")
     expect(data[6]["attributes"]["chance_precip"]).to eq(0.42)
   end
+
+  it 'will create a location if a user searches a non-database city' do
+    get '/api/v1/forecast?location=boulder,co'
+
+    boulder = Location.last
+    expect(boulder.city_state).to eq("Boulder, CO")
+  end
 end

--- a/spec/services/pixabay_service_spec.rb
+++ b/spec/services/pixabay_service_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+describe PixabayService do
+  it '.get_background returns an image url for a city' do
+    image_service = PixabayService.new("Denver, CO")
+    image = image_service.get_background
+
+    expect(image).to be_a(String)
+  end
+
+  it '.get_background returns a default image if there is not a match' do
+    image_service = PixabayService.new("Wichita, KS")
+    image = image_service.get_background
+
+    expect(image).to eq("https://pixabay.com/photos/cornfield-wheat-field-cereals-grain-1651379/")
+  end
+end


### PR DESCRIPTION
- Adds a helper method in Forecast Controller to create a new Location if the city does not exist in the database.
- Creates a test that the city is created
- Creates a test for PixabayService & default image.

All tests passing, 100% test coverage.